### PR TITLE
Position recalculation fix

### DIFF
--- a/lib/network/modules/SelectionHandler.js
+++ b/lib/network/modules/SelectionHandler.js
@@ -653,9 +653,9 @@ class SelectionHandler {
     }
 
     if (object !== undefined) {
-      const hoveredEdgesCound = Object.keys(this.hoverObj.edges).length;
+      const hoveredEdgesCount = Object.keys(this.hoverObj.edges).length;
       const hoveredNodesCount = Object.keys(this.hoverObj.nodes).length;
-      const newOnlyHoveredEdge = object instanceof Edge && hoveredEdgesCound === 0 && hoveredNodesCount === 0;
+      const newOnlyHoveredEdge = object instanceof Edge && hoveredEdgesCount === 0 && hoveredNodesCount === 0;
 
       if (hoverChanged || newOnlyHoveredEdge) {
         hoverChanged = this.emitHoverEvent(event, pointer, object);

--- a/lib/network/modules/components/Node.js
+++ b/lib/network/modules/components/Node.js
@@ -139,7 +139,7 @@ class Node {
     this.updateLabelModule(options);
     this.updateShape(currentShape);
 
-    return (options.hidden !== undefined || options.physics !== undefined);
+    return options.physics !== undefined;
   }
 
 


### PR DESCRIPTION
Currently, whenever we interact with a node that has the property `hidden` set (it doesn't matter if it's true or false), the topology positions are automatically re-calculated. This is an undesired behavior.

To give some background, this is a hotfix for the release R1907. But on the long-term we intend to write ourselves the algorithm to calculate the node positions on the linear layouts, as we already did for the radial layout.

The gifs below show the behavior before and after this change.

Before:
![position-recalculation-bug](https://user-images.githubusercontent.com/47110290/60667550-10609d80-9e6a-11e9-9648-6c2984d1c4e1.gif)


After (additional changes were performed on contrail-ui side [on this PR]
![postion-recalculation-fixed](https://user-images.githubusercontent.com/47110290/60669593-f8d7e380-9e6e-11e9-8a6a-46a7f0d580b0.gif)


